### PR TITLE
Correction to 'Calculate...' sentence

### DIFF
--- a/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-age/outcomes/bus_pass_result.govspeak.erb
@@ -4,10 +4,10 @@
 <% end %>
 
 <% content_for :body do %>
-  The date you qualify for a bus pass depends on where you live:
+  The date you qualify for a bus pass is:
 
-  - on <%= format_date(calculator.bus_pass_qualification_date) %> in England
-  - when you turn 60 years old in [Scotland](http://www.transportscotland.gov.uk/public-transport/concessionary-travel-people-aged-60-or-disability),[Wales](http://wales.gov.uk/topics/transport/public/concessionary/?lang=en),[Northern Ireland](http://www.nidirect.gov.uk/free-bus-travel-and-concessions)
+  - on <%= format_date(calculator.bus_pass_qualification_date) %>, if you live in England
+  - when you turn 60 years old, if you live in [Scotland](http://www.transportscotland.gov.uk/public-transport/concessionary-travel-people-aged-60-or-disability),[Wales](http://wales.gov.uk/topics/transport/public/concessionary/?lang=en) or [Northern Ireland](http://www.nidirect.gov.uk/free-bus-travel-and-concessions)
 
   The dates may be different in some areas, check with your council when you can [apply for a bus pass](/apply-for-elderly-person-bus-pass).
 

--- a/lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb
@@ -9,7 +9,7 @@
 <% content_for :body do %>
   Until 5 April 2017 you’ll be able to apply to make a ‘Class 3A voluntary contribution’ to top up your State Pension by up to £25 per week.
 
-  Calculate how much you’ll need to contribute. You must be Calculate how much you’ll need to contribute. You must be [entitled to the State Pension](/state-pension/eligibility) and either:
+  Calculate how much you’ll need to contribute. You must be [entitled to the State Pension](/state-pension/eligibility) and either:
 
   - a man born before 6 April 1951
   - a woman born before 6 April 1953

--- a/lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb
+++ b/lib/smart_answer_flows/state-pension-topup/state_pension_topup.govspeak.erb
@@ -7,9 +7,9 @@
 <% end %>
 
 <% content_for :body do %>
-  From 12 October 2015 to 5 April 2017 you’ll be able to apply to make a ‘Class 3A voluntary contribution’ to top up your State Pension by up to £25 per week.
+  Until 5 April 2017 you’ll be able to apply to make a ‘Class 3A voluntary contribution’ to top up your State Pension by up to £25 per week.
 
-  Calculate how much you’ll need to contribute. You must be:
+  Calculate how much you’ll need to contribute. You must be Calculate how much you’ll need to contribute. You must be [entitled to the State Pension](/state-pension/eligibility) and either:
 
   - a man born before 6 April 1951
   - a woman born before 6 April 1953
@@ -32,6 +32,4 @@
   You’ll make a lump sum payment of £4,135.
   $E
 
-  ###Eligibility
-  You must be entitled to the basic State Pension or Additional State Pension before 6 April 2016.
 <% end %>


### PR DESCRIPTION
Change “Calculate how much you’ll need to contribute. You must be
Calculate how much you’ll need to contribute. You must be [entitled to
the State Pension](/state-pension/eligibility) and either:”

to

“Calculate how much you’ll need to contribute. You must be [entitled to
the State Pension](/state-pension/eligibility) and either:”
